### PR TITLE
[#120100877] Add contact IDs to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ resource "pingdom_check" "example" {
     resolution = 5
 }
 
+resource "pingdom_check" "example_with_alert" {
+    type = "http"
+    name = "my http check"
+    host = "example.com"
+    resolution = 5
+    uselegacynotifications = true
+    sendtoemail = true
+    sendnotificationwhendown = 2
+    contactids = [
+      12345678
+    ]
+}
+
 resource "pingdom_check" "ping_example" {
     type = "ping"
     name = "my ping check"
@@ -134,6 +147,8 @@ The following common attributes for all check types can be set:
 **notifywhenbackup** - Notify when backup.
 
 **uselegacynotifications** - Use legacy (UP/DOWN) notifications if true.
+
+**contactids** - List of integer contact IDs that will receive the alerts. The ID can be extracted from the contact page URL on the pingdom website.
 
 #### HTTP specific attibutes ####
 


### PR DESCRIPTION
## What

[#120100877 - Email Alerts from Pingdom](https://www.pivotaltracker.com/story/show/120100877)

We want to be able to set up Pingdom checks that alert us via email. For this you need to provide a list of contact IDs of email recipients. 

This change will allow you to set the `contactids` field in a `pingdom_check` resource. The field takes a list of contact IDs as integers. The contact IDs are then provided when [creating a Pingdom check](https://www.pingdom.com/resources/api#MethodCreate+New+Check).
## How to review

The code introduced here is dependent on [pull request 2](https://github.com/alphagov/paas-go-pingdom/pull/2) in the paas-go-pingdom repository.
- `go get` the [go-pingdom](https://github.com/russellcardullo/go-pingdom) library so it is under your `GOPATH`.
- Add alphagov as a remote for [our fork of this library](https://github.com/alphagov/paas-go-pingdom)
- Check out branch `120100877_contact_ids` of our fork (or `gds_master` if pull request 2 has been merged).
- `go get` the [terraform-provider-pingdom](https://github.com/russellcardullo/terraform-provider-pingdom) repository. 
- Add alphagov as a remote for [our fork of this library](https://github.com/alphagov/paas-terraform-provider-pingdom)
- Check out branch `120100877_contact_ids` of this repository
- Run `go build -v`. This should compile the binary to your current directory.
- Replace the binary in paas-cf with the one you have just created. The binaries are in `paas-cf/terraform/providers` and will depend on your OS. This is just a local change that can be checked out when this pull request has been reviewed.
- Set up dev Pingdom checks using the instructions in the paas-cf README
- If you get an error such as `Incompatible API version with plugin. Plugin version: 1, Ours: 2`it means your terraform version and the one checked out by go differ. Go to `$GOPATH/src/github.com/hashicorp/terraform` and checkout the right version (ex: v0.6.16). Then run the build again. 
- Change the checks to add alerts using the sample Terraform config below. 
- Log into the Pingdom UI. It should have email alerts set up with our team email address as a recipient.

```
variable "pingdom_user" {}
variable "pingdom_password" {}
variable "pingdom_api_key" {}
variable "pingdom_account_email" {}
variable "apps_dns_zone_name" {}
variable "env" {}

provider "pingdom" {
    user = "${var.pingdom_user}"
    password = "${var.pingdom_password}"
    api_key = "${var.pingdom_api_key}"
    account_email = "${var.pingdom_account_email}"
}

resource "pingdom_check" "paas_http_healthcheck" {
    type = "http"
    name = "PaaS HTTPS - ${var.env}"
    host = "healthcheck.${var.apps_dns_zone_name}"
    encryption = true
    resolution = 1
    uselegacynotifications = true
    sendtoemail = true
    sendnotificationwhendown = 6
    contactids = [
        11089310
    ]
}

resource "pingdom_check" "paas_db_healthcheck" {
    type = "http"
    name = "PaaS DB - ${var.env}"
    host = "healthcheck.${var.apps_dns_zone_name}"
    url  = "/db"
    encryption = true
    resolution = 1
    uselegacynotifications = true
    sendtoemail = true
    sendnotificationwhendown = 5
    contactids = [
        11089310
    ]
}
```

**Note:** `uselegacynotifications` turns on basic alerting and `sendtoemail` in combination with the `contactids` configures the alerts.
## Who

Anyone but @saliceti @combor or me
